### PR TITLE
Fix docs - mock pyspark import

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,3 +178,5 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+
+autodoc_mock_imports = ["pyspark"]


### PR DESCRIPTION
Docs couldn't be built by readthedocs because of the pyspark dependency.