### PR TITLE
Add secret token to driver - executor communication

### DIFF
--- a/maggy/core/config.py
+++ b/maggy/core/config.py
@@ -1,0 +1,12 @@
+
+import os
+
+mode = None
+
+try:
+    mode = os.environ['HOPSWORKS_VERSION']
+    print("You are running maggy on Hopsworks.")
+    import hops.util as hopsutil
+    import hops.hdfs as hopshdfs
+except KeyError:
+    print("You are running maggy in pure Spark mode.")

--- a/maggy/core/config.py
+++ b/maggy/core/config.py
@@ -1,12 +1,15 @@
 
 import os
 
+HOPSWORKS = "HOPSWORKS"
+SPARK_ONLY = "SPARK_ONLY"
+
 mode = None
 
 try:
     mode = os.environ['HOPSWORKS_VERSION']
+    mode = HOPSWORKS
     print("You are running maggy on Hopsworks.")
-    import hops.util as hopsutil
-    import hops.hdfs as hopshdfs
 except KeyError:
+    mode = SPARK_ONLY
     print("You are running maggy in pure Spark mode.")

--- a/maggy/core/exceptions.py
+++ b/maggy/core/exceptions.py
@@ -1,0 +1,7 @@
+
+class EarlyStopException(Exception):
+
+    def __init__(self, metric):
+        super().__init__()
+
+        self.metric = metric

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -244,6 +244,6 @@ class ExperimentDriver(object):
             'executors': self.num_executors,
             # TODO: add tensorboard logdir
             'logdir': 'UNDEFINED',
-            'hyperparameter_space': self.searchspace.to_dict(),
+            'hyperparameter_space': json.dumps(self.searchspace.to_dict()),
             # 'versioned_resources': versioned_resources,
             'description': self.description})

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -14,7 +14,7 @@ from maggy.trial import Trial
 from maggy.earlystop import AbstractEarlyStop, MedianStoppingRule
 from maggy.searchspace import Searchspace
 
-if config.mode is not None:
+if config.mode is config.HOPSWORKS:
     from hops import constants
     from hops import hdfs
 

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -5,6 +5,7 @@ import queue
 import threading
 import datetime
 import json
+import hops.util as hopsutil
 import maggy.util as util
 from maggy.optimizer import AbstractOptimizer, RandomSearch
 from maggy.core import rpc
@@ -83,7 +84,7 @@ class ExperimentDriver(object):
 
         result = self.optimizer.finalize_experiment(self._final_store)
 
-        self.duration = util._time_diff(job_start, job_end)
+        self.duration = hopsutil._time_diff(job_start, job_end)
 
         if self.direction == 'max':
             results = '\n------ ' + str(self.optimizer.__class__.__name__) + ' results ------ direction(' + self.direction + ') \n' \
@@ -164,7 +165,7 @@ class ExperimentDriver(object):
                     with trial.lock:
                         trial.status = Trial.FINALIZED
                         trial.final_metric = msg['data']
-                        trial.duration = util._time_diff(
+                        trial.duration = hopsutil._time_diff(
                             trial.start, datetime.datetime.now())
 
                     # move trial to the finalized ones

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -4,7 +4,7 @@ API Module for the user to include in his training code.
 """
 import threading
 
-from maggy import util
+from maggy.core import exceptions
 
 class Reporter(object):
     """
@@ -24,7 +24,7 @@ class Reporter(object):
             # if stop == True -> raise exception to break training function
             self.metric = metric
             if self.stop:
-                raise util.EarlyStopException(metric)
+                raise exceptions.EarlyStopException(metric)
 
     def get_metric(self):
 

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -5,7 +5,7 @@ import pickle
 import time
 import select
 import socket
-import hops.util as hopsutil
+import secrets
 
 from maggy import util
 from maggy.trial import Trial
@@ -322,7 +322,7 @@ class Server(MessageSocket):
         server_sock.listen(10)
 
         # hostname may not be resolvable but IP address probably will be
-        host = hopsutil._get_ip_address()
+        host = util._get_ip_address()
         port = server_sock.getsockname()[1]
         addr = (host, port)
 
@@ -341,6 +341,13 @@ class Server(MessageSocket):
                     else:
                         try:
                             msg = self.receive(sock)
+
+                            # raise exception if secret does not match
+                            # so client socket gets closed
+                            if not secrets.compare_digest(msg['secret'],
+                                                          exp_driver._secret):
+                                raise Exception
+
                             self._handle_message(sock, msg, driver)
                         except Exception as e:
                             _ = e
@@ -377,7 +384,7 @@ class Client(MessageSocket):
         self.hb_sock.connect(server_addr)
         self.server_addr = server_addr
         self.done = False
-        self.client_addr = (hopsutil._get_ip_address(), self.sock.getsockname()[1])
+        self.client_addr = (util._get_ip_address(), self.sock.getsockname()[1])
         self.partition_id = partition_id
         self.task_attempt = task_attempt
         self.hb_interval = hb_interval

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -5,6 +5,7 @@ import pickle
 import time
 import select
 import socket
+import hops.util as hopsutil
 
 from maggy import util
 from maggy.trial import Trial
@@ -321,7 +322,7 @@ class Server(MessageSocket):
         server_sock.listen(10)
 
         # hostname may not be resolvable but IP address probably will be
-        host = util._get_ip_address()
+        host = hopsutil._get_ip_address()
         port = server_sock.getsockname()[1]
         addr = (host, port)
 
@@ -376,7 +377,7 @@ class Client(MessageSocket):
         self.hb_sock.connect(server_addr)
         self.server_addr = server_addr
         self.done = False
-        self.client_addr = (util._get_ip_address(), self.sock.getsockname()[1])
+        self.client_addr = (hopsutil._get_ip_address(), self.sock.getsockname()[1])
         self.partition_id = partition_id
         self.task_attempt = task_attempt
         self.hb_interval = hb_interval

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -368,7 +368,7 @@ class Client(MessageSocket):
     Args:
         :server_addr: a tuple of (host, port) pointing to the Server.
     """
-    def __init__(self, server_addr, partition_id, task_attempt, hb_interval):
+    def __init__(self, server_addr, partition_id, task_attempt, hb_interval, secret):
         # socket for main thread
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.connect(server_addr)
@@ -381,12 +381,14 @@ class Client(MessageSocket):
         self.partition_id = partition_id
         self.task_attempt = task_attempt
         self.hb_interval = hb_interval
+        self._secret = secret
 
     def _request(self, req_sock, msg_type, msg_data=None, trial_id=None):
         """Helper function to wrap msg w/ msg_type."""
         msg = {}
         msg['partition_id'] = self.partition_id
         msg['type'] = msg_type
+        msg['secret'] = self._secret
 
         if msg_type == 'FINAL' or msg_type == 'METRIC':
             msg['trial_id'] = trial_id

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -1,7 +1,7 @@
 import socket
 import time
 from maggy import util
-from maggy.core import rpc
+from maggy.core import rpc, exceptions
 from maggy.core.reporter import Reporter
 from pyspark import TaskContext
 
@@ -58,7 +58,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval):
                     print("Starting Trial: {}".format(trial_id))
                     print("Parameter Combination: {}".format(parameters))
                     retval = map_fun(**parameters, reporter=reporter)
-                except util.EarlyStopException as e:
+                except exceptions.EarlyStopException as e:
                     retval = e.metric
                     print("Early Stopped Trial.")
                 finally:

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -6,7 +6,7 @@ from maggy.core.reporter import Reporter
 from pyspark import TaskContext
 
 
-def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval):
+def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret):
 
     def _wrapper_fun(iter):
         """
@@ -24,7 +24,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval):
         partition_id, task_attempt = util.get_partition_attempt_id()
 
         client = rpc.Client(server_addr, partition_id,
-                            task_attempt, hb_interval)
+                            task_attempt, hb_interval, secret)
         reporter = Reporter()
 
         try:

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -105,7 +105,7 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
 
         experiment_json = exp_driver.json(sc)
 
-        util._put_elastic(hopshdfs.project_name(), app_id, elastic_id,
+        hopsutil._put_elastic(hopshdfs.project_name(), app_id, elastic_id,
             experiment_json)
 
         # Force execution on executor, since GPU is located on executor

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -25,7 +25,7 @@ elastic_id = 1
 experiment_json = None
 driver_tensorboard_hdfs_path = None
 
-if config.mode is not None:
+if config.mode is config.HOPSWORKS:
     import hops.util as hopsutil
     import hops.hdfs as hdfs
 
@@ -107,7 +107,7 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
 
         server_addr = exp_driver.server_addr
 
-        if config.mode is not None:
+        if config.mode is config.HOPSWORKS:
             experiment_json = exp_driver.json(sc)
             hopsutil._put_elastic(hdfs.project_name(), app_id, elastic_id,
                 experiment_json)
@@ -120,7 +120,7 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
 
         result = exp_driver.finalize(job_start, job_end)
 
-        if config.mode is not None:
+        if config.mode is config.HOPSWORKS:
             experiment_json = exp_driver.json(sc)
             hopsutil._put_elastic(hdfs.project_name(), app_id, elastic_id,
                 experiment_json)
@@ -128,7 +128,7 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
         print("Finished Experiment \n")
 
     except:
-        if config.mode is not None:
+        if config.mode is config.HOPSWORKS:
             _exception_handler()
         raise
     finally:

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -11,6 +11,7 @@ provided information.
 import socket
 import datetime
 import hops.util as hopsutil
+import hops.hdfs as hopshdfs
 
 from maggy import util
 from maggy.core import rpc

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -9,7 +9,6 @@ invoked it is also registered in the Experiments service along with the
 provided information.
 """
 import socket
-import datetime
 import os
 import json
 import hops.util as hopsutil
@@ -121,10 +120,10 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
                 experiment_json)
 
         # Force execution on executor, since GPU is located on executor
-        job_start = datetime.datetime.now()
+        job_start = datetime.now()
         nodeRDD.foreachPartition(trialexecutor._prepare_func(app_id, run_id,
             map_fun, server_addr, hb_interval))
-        job_end = datetime.datetime.now()
+        job_end = datetime.now()
 
         result = exp_driver.finalize(job_start, job_end)
 

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -170,5 +170,5 @@ def _exit_handler():
         experiment_json = json.dumps(experiment_json)
         hopsutil._put_elastic(hdfs.project_name(), app_id, elastic_id, experiment_json)
 
-if config.mode is not None:
+if config.mode is config.HOPSWORKS:
     atexit.register(_exit_handler)

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -10,6 +10,7 @@ provided information.
 """
 import socket
 import datetime
+import hops.util as hopsutil
 
 from maggy import util
 from maggy.core import rpc
@@ -19,10 +20,7 @@ from maggy.trial import Trial
 
 app_id = None
 running = False
-
-# TODO: this should be inferred from HDFS checkpoints
-run_id = 0
-
+run_id = None
 elastic_id = 1
 experiment_json = None
 driver_tensorboard_hdfs_path = None
@@ -70,8 +68,7 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
     assert num_trials > 0, "number of trials should be greater than zero"
 
     global running
-    # move run_id to the class of the optimizer
-    # global run_id
+
     if running:
         raise RuntimeError("An experiment is currently running.")
 
@@ -81,7 +78,7 @@ def launch(map_fun, searchspace, optimizer, direction, num_trials, name, hb_inte
         global elastic_id
         running = True
 
-        sc = util._find_spark().sparkContext
+        sc = hopsutil._find_spark().sparkContext
         app_id = str(sc.applicationId)
 
         num_executors = util.num_executors()

--- a/maggy/searchspace.py
+++ b/maggy/searchspace.py
@@ -19,6 +19,7 @@ class Searchspace(object):
     or the discrete possible values for the types DISCRETE and CATEGORICAL.
 
     Sample usage:
+
     >>> # Define Searchspace
     >>> from maggy import Searchspace
     >>> # The searchspace can be instantiated with parameters
@@ -27,6 +28,7 @@ class Searchspace(object):
     >>> sp.add('dropout', ('DOUBLE', [0.01, 0.99]))
 
     The `Searchspace` object can also be initialized from a python dictionary:
+
     >>> sp_dict = sp.to_dict()
     >>> sp_new = Searchspace(**sp_dict)
 

--- a/maggy/searchspace.py
+++ b/maggy/searchspace.py
@@ -18,6 +18,18 @@ class Searchspace(object):
     and end point of of the feasible interval for DOUBLE and INTEGER,
     or the discrete possible values for the types DISCRETE and CATEGORICAL.
 
+    Sample usage:
+    >>> # Define Searchspace
+    >>> from maggy import Searchspace
+    >>> # The searchspace can be instantiated with parameters
+    >>> sp = Searchspace(kernel=('INTEGER', [2, 8]), pool=('INTEGER', [2, 8]))
+    >>> # Or additional parameters can be added one by one
+    >>> sp.add('dropout', ('DOUBLE', [0.01, 0.99]))
+
+    The `Searchspace` object can also be initialized from a python dictionary:
+    >>> sp_dict = sp.to_dict()
+    >>> sp_new = Searchspace(**sp_dict)
+
     The parameter names are added as attributes of `Searchspace` object,
     so they can be accessed directly with the dot notation
     `searchspace._name_`.

--- a/maggy/util.py
+++ b/maggy/util.py
@@ -4,6 +4,12 @@ from pyspark.sql import SparkSession
 from pyspark import TaskContext
 
 
+def _get_directories(name):
+    """Checks if experiment directories exist in HDFS and if not creates them
+    """
+    pass
+
+
 def num_executors():
     """
     Get the number of executors configured for Jupyter

--- a/maggy/util.py
+++ b/maggy/util.py
@@ -1,31 +1,8 @@
 import socket
+import hops.util as hopsutil
 from pyspark.sql import SparkSession
 from pyspark import TaskContext
 
-
-def _find_spark():
-    """
-
-    Returns:
-        SparkSession
-    """
-    return SparkSession.builder.getOrCreate()
-
-def _get_ip_address():
-    """
-    Simple utility to get host IP address
-
-    Returns:
-        x
-    """
-    try:
-	    _, _, _, _, addr = socket.getaddrinfo(socket.gethostname(),
-                                              None,
-                                              socket.AF_INET,
-                                              socket.SOCK_STREAM)[0]
-	    return addr[0]
-    except:
-	    return socket.gethostbyname(socket.getfqdn())
 
 def num_executors():
     """
@@ -34,7 +11,7 @@ def num_executors():
     Returns:
         Number of configured executors for Jupyter
     """
-    sc = _find_spark().sparkContext
+    sc = hopsutil._find_spark().sparkContext
     try:
         return int(sc._conf.get('spark.dynamicAllocation.maxExecutors'))
     except:
@@ -58,28 +35,3 @@ def get_partition_attempt_id():
 def print_trial_store(store):
     for _, value in store.items():
         print(value.to_json())
-
-def _time_diff(task_start, task_end):
-    """
-    Args:
-        :task_start:
-        :tast_end:
-
-    Returns:
-
-    """
-    time_diff = task_end - task_start
-
-    seconds = time_diff.seconds
-
-    if seconds < 60:
-        return str(int(seconds)) + ' seconds'
-    elif seconds == 60 or seconds <= 3600:
-        minutes = float(seconds) / 60.0
-        return str(int(minutes)) + ' minutes, ' + str((int(seconds) % 60)) + ' seconds'
-    elif seconds > 3600:
-        hours = float(seconds) / 3600.0
-        minutes = (hours % 1) * 60
-        return str(int(hours)) + ' hours, ' + str(int(minutes)) + ' minutes'
-    else:
-        return 'unknown time'

--- a/maggy/util.py
+++ b/maggy/util.py
@@ -9,7 +9,6 @@ def _get_directories(name):
     """
     pass
 
-
 def num_executors():
     """
     Get the number of executors configured for Jupyter

--- a/maggy/util.py
+++ b/maggy/util.py
@@ -83,10 +83,3 @@ def _time_diff(task_start, task_end):
         return str(int(hours)) + ' hours, ' + str(int(minutes)) + ' minutes'
     else:
         return 'unknown time'
-
-class EarlyStopException(Exception):
-
-    def __init__(self, metric):
-        super().__init__()
-
-        self.metric = metric


### PR DESCRIPTION
Changes:

- Refactors the EarlyStopException into a separate module
- Add sample usage to Searchspace docstring
- Add config module to check for execution mode: spark only or hopsworks
- Publish Maggy experiment data to elastic search if run on hopsworks
- Add secret token to experiment driver for communication with executors (receiving message from client with wrong token will close the client socket)