### PR TITLE
Bugfix return types

### DIFF
--- a/maggy/constants.py
+++ b/maggy/constants.py
@@ -1,0 +1,9 @@
+"""
+Constants used in Maggy: Allowed datatypes etc.
+"""
+import numpy as np
+
+class USER_FCT:
+    """Return datatypes allowed for user defined training function.
+    """
+    RETURN_TYPES = (float, int, np.number)

--- a/maggy/constants.py
+++ b/maggy/constants.py
@@ -4,6 +4,6 @@ Constants used in Maggy: Allowed datatypes etc.
 import numpy as np
 
 class USER_FCT:
-    """Return datatypes allowed for user defined training function.
+    """User traingin function specifics.
     """
     RETURN_TYPES = (float, int, np.number)

--- a/maggy/constants.py
+++ b/maggy/constants.py
@@ -4,6 +4,6 @@ Constants used in Maggy: Allowed datatypes etc.
 import numpy as np
 
 class USER_FCT:
-    """User traingin function specifics.
+    """User training function specifics.
     """
     RETURN_TYPES = (float, int, np.number)

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -1,6 +1,6 @@
 import socket
 import time
-from maggy import util, tensorboard
+from maggy import util, tensorboard, constants
 from maggy.core import rpc, exceptions, config
 from maggy.core.reporter import Reporter
 from pyspark import TaskContext
@@ -76,7 +76,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                         reporter.log(
                             "ERROR: Training function can't return None", True)
                         raise Exception("Training function can't return None")
-                    elif not isinstance(retval, float) or not isinstance(retval, int):
+                    elif not isinstance(retval, constants.USER_FCT.RETURN_TYPES):
                         reporter.log(
                             "ERROR: Training function returns non numeric value: {}"
                             .format(type(retval)), True)


### PR DESCRIPTION
- Fixes bug: user function can now return Numpy.float32 type
- Not all Numpy numeric datatypes derive from Python standard types
- Introduce constants.py module