### PR TITLE
Refactoring for progress bar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,6 +179,6 @@ epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 
-autodoc_mock_imports = ['pyspark', 'pydoop', 'hops', 'tensorflow']
+autodoc_mock_imports = ['pyspark', 'pydoop', 'hops', 'tensorflow', 'tensorboard']
 
 exclude_patterns = ['core/config.py']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,4 +179,4 @@ epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 
-autodoc_mock_imports = ['pyspark', 'tensorflow', 'pydoop']
+autodoc_mock_imports = ['pyspark', 'pydoop']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,6 +179,6 @@ epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 
-autodoc_mock_imports = ['pyspark', 'pydoop', 'hops']
+autodoc_mock_imports = ['pyspark', 'pydoop', 'hops', 'tensorflow']
 
 exclude_patterns = ['core/config.py']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,3 +180,5 @@ epub_exclude_files = ['search.html']
 # -- Extension configuration -------------------------------------------------
 
 autodoc_mock_imports = ['pyspark', 'pydoop', 'tensorflow']
+
+exclude_patterns = ['core/config.py']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,4 +179,4 @@ epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 
-autodoc_mock_imports = ['pyspark', 'pydoop']
+autodoc_mock_imports = ['pyspark', 'pydoop', 'tensorflow']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,6 +179,6 @@ epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 
-autodoc_mock_imports = ['pyspark', 'pydoop', 'tensorflow']
+autodoc_mock_imports = ['pyspark', 'pydoop', 'hops']
 
 exclude_patterns = ['core/config.py']

--- a/maggy/core/config.py
+++ b/maggy/core/config.py
@@ -7,6 +7,7 @@ SPARK_ONLY = "SPARK_ONLY"
 
 mode = None
 tf_full = tf.__version__.split(".")[0]
+# for building the docs since mock object doesn't mock int()
 if not isinstance(tf_full, str):
     tf_version = 2
 else:

--- a/maggy/core/config.py
+++ b/maggy/core/config.py
@@ -6,7 +6,11 @@ HOPSWORKS = "HOPSWORKS"
 SPARK_ONLY = "SPARK_ONLY"
 
 mode = None
-tf_version = int(tf.__version__.split(".")[0])
+tf_full = tf.__version__.split(".")[0]
+if not isinstance(tf_full, str):
+    tf_version = 2
+else:
+    tf_version = int(tf_full)
 
 try:
     mode = os.environ['HOPSWORKS_VERSION']

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -177,6 +177,8 @@ class ExperimentDriver(object):
                 if msg['type'] == 'METRIC':
                     self.get_trial(msg['trial_id']).append_metric(msg['data'])
 
+                    print('METRIC: {}'.format(msg))
+
                     # append executor logs if in the message
                     logs = msg.get('logs', None)
                     if logs is not None:

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -278,12 +278,8 @@ class ExperimentDriver(object):
             experiment_json['status'] = "FINISHED"
             experiment_json['finished'] = self.job_end.isoformat()
             experiment_json['duration'] = self.duration
-            if self.direction == 'max':
-                experiment_json['hyperparameter'] = json.dumps(self.result['max_hp'])
-                experiment_json['metric'] = self.result['max_val']
-            elif self.direction == 'min':
-                experiment_json['hyperparameter'] = json.dumps(self.result['min_hp'])
-                experiment_json['metric'] = self.result['min_val']
+            experiment_json['hyperparameter'] = json.dumps(self.result['best_hp'])
+            experiment_json['metric'] = self.result['best_val']
 
         else:
             experiment_json['status'] = "RUNNING"
@@ -353,8 +349,8 @@ class ExperimentDriver(object):
         log = 'Maggy ' + str(finished) + '/' + str(self.num_trials) + \
             ' (' + str(self.result['early_stopped']) + ') ' + \
             util._progress_bar(finished, self.num_trials) + ' - BEST ' + \
-            json.dumps(self.result['max_hp']) + ' - metric ' + \
-            str(self.result['max_val'])
+            json.dumps(self.result['best_hp']) + ' - metric ' + \
+            str(self.result['best_val'])
 
         return log
 

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -175,12 +175,9 @@ class ExperimentDriver(object):
                 # depending on message do the work
                 # 1. METRIC
                 if msg['type'] == 'METRIC':
-                    print("METRIC MSG: {}".format(msg))
-
                     # append executor logs if in the message
                     logs = msg.get('logs', None)
                     if logs is not None:
-                        print("METRIC: {}".format(msg['logs']))
                         with self.log_lock:
                             self.executor_logs = self.executor_logs + logs
 

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -342,7 +342,7 @@ class ExperimentDriver(object):
             len(self.result['metric_list']))
 
         if trial.early_stop:
-                self.result['early_stopped'] += 1
+            self.result['early_stopped'] += 1
 
     def _update_maggy_log(self):
         """Creates the status of a maggy experiment with a progress bar.

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -9,7 +9,7 @@ import secrets
 from datetime import datetime
 from maggy import util
 from maggy.optimizer import AbstractOptimizer, RandomSearch
-from maggy.core import config, rpc
+from maggy.core import rpc
 from maggy.trial import Trial
 from maggy.earlystop import AbstractEarlyStop, MedianStoppingRule
 from maggy.searchspace import Searchspace

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -80,7 +80,7 @@ class ExperimentDriver(object):
         self.direction = direction.lower()
         self.server = rpc.Server(num_executors)
         self._secret = self._generate_secret(ExperimentDriver.SECRET_BYTES)
-        self.result = {'best_val': 'no Trial finished yet',
+        self.result = {'best_val': 'n.a.',
             'num_trials': 0,
             'early_stopped': 0}
         self.job_start = datetime.now()

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -177,13 +177,10 @@ class ExperimentDriver(object):
                 if msg['type'] == 'METRIC':
                     self.get_trial(msg['trial_id']).append_metric(msg['data'])
 
-                    print('METRIC: {}'.format(msg))
-
                     # append executor logs if in the message
                     logs = msg.get('logs', None)
                     if logs is not None:
                         with self.log_lock:
-                            print('update logs with; {}'.format(logs))
                             self.executor_logs = self.executor_logs + logs
 
                 # 2. BLACKLIST the trial

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -177,6 +177,8 @@ class ExperimentDriver(object):
                 if msg['type'] == 'METRIC':
                     self.get_trial(msg['trial_id']).append_metric(msg['data'])
 
+                    print("METRIC MSG: {}".format(msg))
+
                     # append executor logs if in the message
                     logs = msg.get('logs', None)
                     if logs is not None:

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -180,6 +180,7 @@ class ExperimentDriver(object):
                     # append executor logs if in the message
                     logs = msg.get('logs', None)
                     if logs is not None:
+                        print("METRIC: {}".format(msg['logs']))
                         with self.log_lock:
                             self.executor_logs = self.executor_logs + logs
 

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -175,8 +175,6 @@ class ExperimentDriver(object):
                 # depending on message do the work
                 # 1. METRIC
                 if msg['type'] == 'METRIC':
-                    self.get_trial(msg['trial_id']).append_metric(msg['data'])
-
                     print("METRIC MSG: {}".format(msg))
 
                     # append executor logs if in the message
@@ -185,6 +183,9 @@ class ExperimentDriver(object):
                         print("METRIC: {}".format(msg['logs']))
                         with self.log_lock:
                             self.executor_logs = self.executor_logs + logs
+
+                    if msg['trial_id'] is not None and msg['data'] is not None:
+                        self.get_trial(msg['trial_id']).append_metric(msg['data'])
 
                 # 2. BLACKLIST the trial
                 elif msg['type'] == 'BLACK':

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -80,7 +80,9 @@ class ExperimentDriver(object):
         self.direction = direction.lower()
         self.server = rpc.Server(num_executors)
         self._secret = self._generate_secret(ExperimentDriver.SECRET_BYTES)
-        self.result = {'best_val': '...', 'num_trials': 0, 'early_stopped': 0}
+        self.result = {'best_val': 'no Trial finished yet',
+            'num_trials': 0,
+            'early_stopped': 0}
         self.job_start = datetime.now()
         self.executor_logs = ''
         self.maggy_log = ''
@@ -179,6 +181,7 @@ class ExperimentDriver(object):
                     logs = msg.get('logs', None)
                     if logs is not None:
                         with self.log_lock:
+                            print('update logs with; {}'.format(logs))
                             self.executor_logs = self.executor_logs + logs
 
                 # 2. BLACKLIST the trial

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -43,23 +43,23 @@ class Reporter(object):
             if self.stop:
                 raise exceptions.EarlyStopException(metric)
 
-    def log(self, log_msg, verbose=False):
-        """Logs a message to the executor logfile and optionally to the
-        executor sterr.
+    def log(self, log_msg, verbose=True):
+        """Logs a message to the executor logfile and executor stderr and
+        optionally prints the message in jupyter.
 
         :param log_msg: Message to log.
         :type log_msg: str
-        :param print_executor: Print to executor sterr, defaults to False
+        :param print_executor: Print in Jupyter Notebook, defaults to True
         :type print_executor: bool, optional
         """
         with self.lock:
             msg = datetime.now().isoformat() + \
                 ' (' + str(self.partition_id) + '/' + \
                 str(self.task_attempt) + '): ' + str(log_msg)
-            if verbose:
-                print(msg)
+            print(msg)
             self.fd.write((msg + '\n').encode())
-            self.logs = self.logs + msg + '\n'
+            if verbose:
+                self.logs = self.logs + msg + '\n'
 
     def get_data(self):
         """Returns the metric and logs to be sent to the experiment driver.

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -49,8 +49,8 @@ class Reporter(object):
 
         :param log_msg: Message to log.
         :type log_msg: str
-        :param print_executor: Print in Jupyter Notebook, defaults to True
-        :type print_executor: bool, optional
+        :param verbose: Print in Jupyter Notebook, defaults to True
+        :type verbose: bool, optional
         """
         with self.lock:
             msg = datetime.now().isoformat() + \

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -278,19 +278,18 @@ class Server(MessageSocket):
             else:
                 send['data'] = None
         elif msg_type == 'LOG':
-            print('Handle LOG message')
             # get data from experiment driver
             result, log = exp_driver._get_logs()
-            print('result: {}'.format(result))
-            print('log: {}'.format(log))
 
             send['type'] = "OK"
-            send['ex_logs'] = log
+            if log:
+                send['ex_logs'] = log
+            else:
+                send['ex_logs'] = None
             send['num_trials'] = exp_driver.num_trials
             send['to_date'] = result['num_trials']
             send['stopped'] = result['early_stopped']
             send['metric'] = result['best_val']
-            print('LOG answer: {}'.format(send))
         else:
             send['type'] = "ERR"
 

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -278,6 +278,7 @@ class Server(MessageSocket):
             else:
                 send['data'] = None
         elif msg_type == 'LOG':
+            print('Handle LOG message')
             # get data from experiment driver
             result, log = exp_driver._get_logs()
 
@@ -287,6 +288,7 @@ class Server(MessageSocket):
             send['to_date'] = result['num_trials']
             send['stopped'] = result['early_stopped']
             send['metric'] = result['max_val']
+            print('LOG answer: {}'.format(send))
         else:
             send['type'] = "ERR"
 

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -365,6 +365,8 @@ class Server(MessageSocket):
                         try:
                             msg = self.receive(sock)
 
+                            print("rcvd: {}".format(msg))
+
                             # raise exception if secret does not match
                             # so client socket gets closed
                             if not secrets.compare_digest(msg['secret'],

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -281,6 +281,8 @@ class Server(MessageSocket):
             print('Handle LOG message')
             # get data from experiment driver
             result, log = exp_driver._get_logs()
+            print('result: {}'.format(result))
+            print('log: {}'.format(log))
 
             send['type'] = "OK"
             send['ex_logs'] = log

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -366,8 +366,6 @@ class Server(MessageSocket):
                         try:
                             msg = self.receive(sock)
 
-                            print(msg)
-
                             # raise exception if secret does not match
                             # so client socket gets closed
                             if not secrets.compare_digest(msg['secret'],

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -483,6 +483,8 @@ class Client(MessageSocket):
 
                 metric, logs = report.get_data()
 
+                print('HB sending: {}'.format(logs))
+
                 resp = self._request(self.hb_sock,
                                     'METRIC',
                                      metric,

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -502,7 +502,7 @@ class Client(MessageSocket):
         t.daemon = True
         t.start()
 
-        reporter.log("Started metric heartbeat", True)
+        reporter.log("Started metric heartbeat", False)
 
     def get_suggestion(self):
         """Blocking call to get new parameter combination."""

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -362,6 +362,8 @@ class Server(MessageSocket):
                         try:
                             msg = self.receive(sock)
 
+                            print(msg)
+
                             # raise exception if secret does not match
                             # so client socket gets closed
                             if not secrets.compare_digest(msg['secret'],

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -289,7 +289,7 @@ class Server(MessageSocket):
             send['num_trials'] = exp_driver.num_trials
             send['to_date'] = result['num_trials']
             send['stopped'] = result['early_stopped']
-            send['metric'] = result['max_val']
+            send['metric'] = result['best_val']
             print('LOG answer: {}'.format(send))
         else:
             send['type'] = "ERR"

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -366,6 +366,8 @@ class Server(MessageSocket):
                             # so client socket gets closed
                             if not secrets.compare_digest(msg['secret'],
                                                           exp_driver._secret):
+                                exp_driver._log("SERVER secret: {}".format(exp_driver._secret))
+                                exp_driver._log("ERROR: wrong secret {}".format(msg['secret']))
                                 raise Exception
 
                             self._handle_message(sock, msg, driver)

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -203,20 +203,6 @@ class Server(MessageSocket):
         # Prepare message
         send = {}
 
-        #if 'trial_id' in msg:
-            # throw away idle heartbeat messages without trial
-        #    if msg['trial_id'] is None:
-        #        send['type'] = 'OK'
-        #        MessageSocket.send(self, sock, send)
-        #        return
-            # it can happen that executor has trial but no metric was reported
-            # yet so trial_id is not None but data is None
-        #    elif msg['trial_id'] is not None:
-        #        if msg.get('data', None) is None:
-        #            send['type'] = 'OK'
-        #            MessageSocket.send(self, sock, send)
-        #            return
-
         if msg_type == 'REG':
             # check if executor was registered before and retrieve lost trial
             lost_trial = self.reservations.get_assigned_trial(msg['partition_id'])
@@ -378,8 +364,6 @@ class Server(MessageSocket):
                         try:
                             msg = self.receive(sock)
 
-                            print("rcvd: {}".format(msg))
-
                             # raise exception if secret does not match
                             # so client socket gets closed
                             if not secrets.compare_digest(msg['secret'],
@@ -503,8 +487,6 @@ class Client(MessageSocket):
             while not self.done:
 
                 metric, logs = report.get_data()
-
-                print('HB sending: {}'.format(logs))
 
                 resp = self._request(self.hb_sock,
                                     'METRIC',

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -88,9 +88,9 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                     retval = e.metric
                     reporter.log("Early Stopped Trial.", True)
                 finally:
+                    client.finalize_metric(retval, reporter)
                     reporter.log("Finished Trial: {}".format(trial_id), True)
                     reporter.log("Final Metric: {}".format(retval), True)
-                    client.finalize_metric(retval, reporter)
 
                 # blocking
                 trial_id, parameters = client.get_suggestion()

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -47,7 +47,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
             exec_spec['host_port'] = host_port
             exec_spec['trial_id'] = None
 
-            reporter.log("Registering with experiment driver", True)
+            reporter.log("Registering with experiment driver", False)
             client.register(exec_spec)
 
             # blocking
@@ -67,30 +67,30 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                 hopshdfs.mkdir(tb_logdir)
 
                 try:
-                    reporter.log("Starting Trial: {}".format(trial_id), True)
-                    reporter.log("Parameter Combination: {}".format(parameters), True)
+                    reporter.log("Starting Trial: {}".format(trial_id), False)
+                    reporter.log("Parameter Combination: {}".format(parameters), False)
                     retval = map_fun(**parameters, reporter=reporter)
 
                     # Make sure user function returns a numeric value
                     if retval is None:
                         reporter.log(
-                            "ERROR: Training function can't return None", True)
+                            "ERROR: Training function can't return None", False)
                         raise Exception("Training function can't return None")
                     elif not isinstance(retval, constants.USER_FCT.RETURN_TYPES):
                         reporter.log(
                             "ERROR: Training function returns non numeric value: {}"
-                            .format(type(retval)), True)
+                            .format(type(retval)), False)
                         raise Exception(
                             "ERROR: Training function returns non numeric value: {}"
                             .format(type(retval)))
 
                 except exceptions.EarlyStopException as e:
                     retval = e.metric
-                    reporter.log("Early Stopped Trial.", True)
+                    reporter.log("Early Stopped Trial.", False)
                 finally:
                     client.finalize_metric(retval, reporter)
-                    reporter.log("Finished Trial: {}".format(trial_id), True)
-                    reporter.log("Final Metric: {}".format(retval), True)
+                    reporter.log("Finished Trial: {}".format(trial_id), False)
+                    reporter.log("Final Metric: {}".format(retval), False)
 
                 # blocking
                 trial_id, parameters = client.get_suggestion()

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -88,9 +88,9 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                     retval = e.metric
                     reporter.log("Early Stopped Trial.", True)
                 finally:
-                    client.finalize_metric(retval, reporter)
                     reporter.log("Finished Trial: {}".format(trial_id), True)
                     reporter.log("Final Metric: {}".format(retval), True)
+                    client.finalize_metric(retval, reporter)
 
                 # blocking
                 trial_id, parameters = client.get_suggestion()

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -15,7 +15,7 @@ import atexit
 from datetime import datetime
 
 from maggy import util, tensorboard
-from maggy.core import config, rpc, trialexecutor, ExperimentDriver
+from maggy.core import rpc, trialexecutor, ExperimentDriver
 from maggy.trial import Trial
 
 from hops import util as hopsutil

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,6 @@ def read(fname):
 setup(
     name='maggy',
     version=__version__,
-    install_requires=[
-        'numpy'
-    ],
-    extras_require={
-        'tf': ['tensorflow']
-    },
     author='Moritz Meister',
     author_email='meister.mo@gmail.com',
     description='',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ def read(fname):
 setup(
     name='maggy',
     version=__version__,
+    install_requires=[
+        'numpy'
+    ],
     author='Moritz Meister',
     author_email='meister.mo@gmail.com',
     description='',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,12 @@ def read(fname):
 setup(
     name='maggy',
     version=__version__,
+    install_requires=[
+        'numpy'
+    ],
+    extras_require={
+        'tf': ['tensorflow']
+    },
     author='Moritz Meister',
     author_email='meister.mo@gmail.com',
     description='',


### PR DESCRIPTION
This PR contains some refactoring for printing the executor logs in Jupyter.
- Heartbeat messages between trials without data were previously simply discarded, now they can contain logs, so this is being taken into account with these changes.
- It also works with Hopsworks versions without the maggy Rest api
- *Adds Numpy as dependency*