### PR TITLE
Add NoStopRule

### DIFF
--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -165,7 +165,6 @@ class ExperimentDriver(object):
                                 self._trial_store, self._final_store, self.direction)
                         except Exception as e:
                             self._log(e)
-                        finally:
                             to_stop = []
                         if len(to_stop) > 0:
                             self._log("Trials to stop: {}".format(to_stop))

--- a/maggy/earlystop/__init__.py
+++ b/maggy/earlystop/__init__.py
@@ -1,2 +1,3 @@
 from maggy.earlystop.abstractearlystop import AbstractEarlyStop
 from maggy.earlystop.medianrule import MedianStoppingRule
+from maggy.earlystop.nostop import NoStoppingRule

--- a/maggy/earlystop/medianrule.py
+++ b/maggy/earlystop/medianrule.py
@@ -30,9 +30,9 @@ class MedianStoppingRule(AbstractEarlyStop):
 
                 try:
                     median = statistics.median(results)
-                except Exception as e:
-                    print(e)
-                    raise
+                except statistics.StatisticsError as e:
+                    raise Exception(
+                        "Warning: StatisticsError when calling early stop method\n{}" .format(e))
 
                 if median is not None:
                     if direction == 'max':

--- a/maggy/earlystop/nostop.py
+++ b/maggy/earlystop/nostop.py
@@ -1,0 +1,10 @@
+from maggy.earlystop import AbstractEarlyStop
+
+
+class NoStoppingRule(AbstractEarlyStop):
+    """The no stopping rule never stops any trials early.
+    """
+    @staticmethod
+    def earlystop_check(to_check, finalized_trials, direction):
+        stop = []
+        return stop


### PR DESCRIPTION
- Add an early stopping rule that does not stop any trials.
- Fix a bug that causes maggy to freeze in case the worker throws an exception due to a StatisticsError