### PR TITLE
Maggy print and reuse port

### DIFF
--- a/maggy/__init__.py
+++ b/maggy/__init__.py
@@ -1,2 +1,1 @@
 from maggy.searchspace import Searchspace
-# from maggy.trial import Trial

--- a/maggy/__init__.py
+++ b/maggy/__init__.py
@@ -1,2 +1,2 @@
 from maggy.searchspace import Searchspace
-from maggy.trial import Trial
+# from maggy.trial import Trial

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -18,12 +18,16 @@ from hops import constants as hopsconstants
 from hops import hdfs as hopshdfs
 from hops import util as hopsutil
 
+driver_secret = None
+
 
 class ExperimentDriver(object):
 
     SECRET_BYTES = 8
 
     def __init__(self, searchspace, optimizer, direction, num_trials, name, num_executors, hb_interval, es_policy, es_interval, es_min, description, app_dir, log_dir, trial_dir):
+
+        global driver_secret
 
         self._final_store = []
 
@@ -96,7 +100,9 @@ class ExperimentDriver(object):
         self.description = description
         self.direction = direction.lower()
         self.server = rpc.Server(num_executors)
-        self._secret = self._generate_secret(ExperimentDriver.SECRET_BYTES)
+        if not driver_secret:
+            driver_secret = self._generate_secret(ExperimentDriver.SECRET_BYTES)
+        self._secret = driver_secret
         self.result = {'best_val': 'n.a.',
             'num_trials': 0,
             'early_stopped': 0}

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -269,15 +269,18 @@ class ExperimentDriver(object):
                 # therefore log the exception and fail experiment
                 self._log('Worker Exception')
                 self._log(worker_exception)
-                self.server.stop()
+                self.stop(worker_exception)
 
 
         t = threading.Thread(target=_target_function, args=(self,))
         t.daemon = True
         t.start()
 
-    def stop(self):
+    def stop(self, worker_exception=None):
         """Stop the Driver's worker thread and server."""
+        if worker_exception:
+            print(worker_exception)
+            return
         self.worker_done = True
         self.server.stop()
         self.fd.flush()

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -265,9 +265,11 @@ class ExperimentDriver(object):
                                     msg['partition_id'], trial.trial_id)
                                 self.add_trial(trial)
             except Exception as worker_exception:
+                # Exception can't be propagated to parent thread
+                # therefore log the exception and fail experiment
                 self._log('Worker Exception')
                 self._log(worker_exception)
-                self.stop()
+                self.server.stop()
 
 
         t = threading.Thread(target=_target_function, args=(self,))

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -282,7 +282,7 @@ class ExperimentDriver(object):
         """Stop the Driver's worker thread and server."""
         if self.worker_exception:
             raise Exception(
-                "Worker exception: {}".format(self.worker_exception))
+                "Worker: {}".format(self.worker_exception))
         self.worker_done = True
         self.server.stop()
         self.fd.flush()

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -8,7 +8,7 @@ import os
 import secrets
 from datetime import datetime
 from maggy import util
-from maggy.optimizer import AbstractOptimizer, RandomSearch, Asha
+from maggy.optimizer import AbstractOptimizer, RandomSearch, Asha, SingleRun
 from maggy.core import rpc
 from maggy.trial import Trial
 from maggy.earlystop import AbstractEarlyStop, MedianStoppingRule, NoStoppingRule
@@ -30,11 +30,19 @@ class ExperimentDriver(object):
         # perform type checks
         if isinstance(searchspace, Searchspace):
             self.searchspace = searchspace
+        elif searchspace is None:
+            self.searchspace = Searchspace()
         else:
             raise Exception(
                 "No valid searchspace. Please use maggy Searchspace class.")
 
-        if isinstance(optimizer, str):
+        if optimizer is None or optimizer.lower() == 'none':
+                if len(self.searchspace.names()) == 0:
+                    self.optimizer = SingleRun()
+                else:
+                    raise Exception(
+                        'Searchspace has to be empty or None to use without optimizer')
+        elif isinstance(optimizer, str):
             if optimizer.lower() == 'randomsearch':
                 self.optimizer = RandomSearch()
             elif optimizer.lower() == 'asha':

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -280,13 +280,13 @@ class ExperimentDriver(object):
 
     def stop(self):
         """Stop the Driver's worker thread and server."""
-        if self.worker_exception:
-            raise Exception(
-                "Worker: {}".format(self.worker_exception))
         self.worker_done = True
         self.server.stop()
         self.fd.flush()
         self.fd.close()
+        if self.worker_exception:
+            raise Exception(
+                "Worker: {}".format(self.worker_exception))
 
     def json(self, sc):
         """Get all relevant experiment information in JSON format.

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -142,7 +142,8 @@ class ExperimentDriver(object):
 
         self._log(results)
 
-        hopshdfs.dump(json.dumps(self.result), self.app_dir + '/result.json')
+        hopshdfs.dump(json.dumps(self.result, default=util.json_default_numpy),
+            self.app_dir + '/result.json')
         sc = hopsutil._find_spark().sparkContext
         hopshdfs.dump(self.json(sc), self.app_dir + '/maggy.json')
 
@@ -320,7 +321,7 @@ class ExperimentDriver(object):
         else:
             experiment_json['status'] = "RUNNING"
 
-        return json.dumps(experiment_json)
+        return json.dumps(experiment_json, default=util.json_default_numpy)
 
     def _generate_secret(self, nbytes):
         """Generates a secret to be used by all clients during the experiment

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -43,7 +43,7 @@ class Reporter(object):
             if self.stop:
                 raise exceptions.EarlyStopException(metric)
 
-    def log(self, log_msg, verbose=True):
+    def log(self, log_msg='', verbose=True):
         """Logs a message to the executor logfile and executor stderr and
         optionally prints the message in jupyter.
 

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -56,7 +56,7 @@ class Reporter(object):
             msg = datetime.now().isoformat() + \
                 ' (' + str(self.partition_id) + '/' + \
                 str(self.task_attempt) + '): ' + str(log_msg)
-            print(msg)
+            # print(msg)
             self.fd.write((msg + '\n').encode())
             jupyter_log = str(self.partition_id) + ': ' + log_msg
             if verbose:

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -43,7 +43,7 @@ class Reporter(object):
             if self.stop:
                 raise exceptions.EarlyStopException(metric)
 
-    def log(self, log_msg='', verbose=True):
+    def log(self, log_msg, verbose=True):
         """Logs a message to the executor logfile and executor stderr and
         optionally prints the message in jupyter.
 

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -14,7 +14,7 @@ class Reporter(object):
     Thread-safe store for sending a metric and logs from executor to driver
     """
 
-    def __init__(self, log_file, partition_id, task_attempt):
+    def __init__(self, log_file, partition_id, task_attempt, print_executor):
         self.metric = None
         self.lock = threading.RLock()
         self.stop = False
@@ -23,6 +23,7 @@ class Reporter(object):
         self.log_file = log_file
         self.partition_id = partition_id
         self.task_attempt = task_attempt
+        self.print_executor = print_executor
 
         #Open File desc for HDFS to log
         if not hopshdfs.exists(log_file):
@@ -60,6 +61,8 @@ class Reporter(object):
             jupyter_log = str(self.partition_id) + ': ' + log_msg
             if verbose:
                 self.logs = self.logs + jupyter_log + '\n'
+            else:
+                self.print_executor(msg)
 
     def get_data(self):
         """Returns the metric and logs to be sent to the experiment driver.

--- a/maggy/core/reporter.py
+++ b/maggy/core/reporter.py
@@ -56,7 +56,6 @@ class Reporter(object):
             msg = datetime.now().isoformat() + \
                 ' (' + str(self.partition_id) + '/' + \
                 str(self.task_attempt) + '): ' + str(log_msg)
-            # print(msg)
             self.fd.write((msg + '\n').encode())
             jupyter_log = str(self.partition_id) + ': ' + log_msg
             if verbose:

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -16,6 +16,8 @@ from hops import util as hopsutil
 MAX_RETRIES = 3
 BUFSIZE = 1024 * 2
 
+server_host_port = None
+
 
 class Reservations(object):
     """Thread-safe store for worker reservations.
@@ -310,41 +312,45 @@ class Server(MessageSocket):
         Returns:
             address of the Server as a tuple of (host, port)
         """
+        global server_host_port
+
         server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        server_sock.bind(('', 0))
+        if not server_host_port:
+            server_sock.bind(('', 0))
+            # hostname may not be resolvable but IP address probably will be
+            host = hopsutil._get_ip_address()
+            port = server_sock.getsockname()[1]
+            server_host_port = (host, port)
+
+            # register this driver with Hopsworks
+            sc = hopsutil._find_spark().sparkContext
+            app_id = str(sc.applicationId)
+
+            method = hopsconstants.HTTP_CONFIG.HTTP_POST
+            connection = hopsutil._get_http_connection(https=True)
+            resource_url = hopsconstants.DELIMITERS.SLASH_DELIMITER + \
+                        hopsconstants.REST_CONFIG.HOPSWORKS_REST_RESOURCE + hopsconstants.DELIMITERS.SLASH_DELIMITER + \
+                        "maggy" + hopsconstants.DELIMITERS.SLASH_DELIMITER + "drivers"
+            json_contents = {"hostIp": host,
+                            "port": port,
+                            "appId": app_id,
+                            "secret" : exp_driver._secret }
+            json_embeddable = json.dumps(json_contents)
+            headers = {hopsconstants.HTTP_CONFIG.HTTP_CONTENT_TYPE: hopsconstants.HTTP_CONFIG.HTTP_APPLICATION_JSON}
+
+            try:
+                response = hopsutil.send_request(connection, method, resource_url, body=json_embeddable, headers=headers)
+                if (response.status != 200):
+                    print("No connection to Hopsworks for logging.")
+                    exp_driver._log("No connection to Hopsworks for logging.")
+            except Exception as e:
+                print("Connection failed to Hopsworks. No logging.")
+                exp_driver._log(e)
+                exp_driver._log("Connection failed to Hopsworks. No logging.")
+        else:
+            server_sock.bind(server_host_port)
         server_sock.listen(10)
-
-        # hostname may not be resolvable but IP address probably will be
-        host = hopsutil._get_ip_address()
-        port = server_sock.getsockname()[1]
-        addr = (host, port)
-
-        # register this driver with Hopsworks
-        sc = hopsutil._find_spark().sparkContext
-        app_id = str(sc.applicationId)
-
-        method = hopsconstants.HTTP_CONFIG.HTTP_POST
-        connection = hopsutil._get_http_connection(https=True)
-        resource_url = hopsconstants.DELIMITERS.SLASH_DELIMITER + \
-                       hopsconstants.REST_CONFIG.HOPSWORKS_REST_RESOURCE + hopsconstants.DELIMITERS.SLASH_DELIMITER + \
-                       "maggy" + hopsconstants.DELIMITERS.SLASH_DELIMITER + "drivers"
-        json_contents = {"hostIp": host,
-                         "port": port,
-                         "appId": app_id,
-                         "secret" : exp_driver._secret }
-        json_embeddable = json.dumps(json_contents)
-        headers = {hopsconstants.HTTP_CONFIG.HTTP_CONTENT_TYPE: hopsconstants.HTTP_CONFIG.HTTP_APPLICATION_JSON}
-
-        try:
-            response = hopsutil.send_request(connection, method, resource_url, body=json_embeddable, headers=headers)
-            if (response.status != 200):
-                print("No connection to Hopsworks for logging.")
-                exp_driver._log("No connection to Hopsworks for logging.")
-        except Exception as e:
-            print("Connection failed to Hopsworks. No logging.")
-            exp_driver._log(e)
-            exp_driver._log("Connection failed to Hopsworks. No logging.")
 
         def _listen(self, sock, driver):
             CONNECTIONS = []
@@ -382,7 +388,7 @@ class Server(MessageSocket):
         t.daemon = True
         t.start()
 
-        return addr
+        return server_host_port
 
     def stop(self):
         """

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -41,13 +41,13 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         # save the builtin print
         original_print = __builtin__.print
 
-        def test_print(*args, **kwargs):
+        def maggy_print(*args, **kwargs):
             """Maggy custom print() function."""
             reporter.log(' '.join(str(x) for x in args))
             original_print(*args, **kwargs)
 
         # override the builtin print
-        __builtin__.print = test_print
+        __builtin__.print = maggy_print
 
         try:
             client_addr = client.client_addr

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -38,16 +38,16 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         log_file = app_dir + '/logs/executor_' + str(partition_id) + '_' + str(task_attempt) + '.log'
         reporter = Reporter(log_file, partition_id, task_attempt)
 
+        # save the builtin print
         original_print = __builtin__.print
 
         def test_print(*args, **kwargs):
             """Maggy custom print() function."""
-            reporter.log(''.join(str(x) for x in args))
+            reporter.log(' '.join(str(x) for x in args))
             original_print(*args, **kwargs)
 
+        # override the builtin print
         __builtin__.print = test_print
-
-        print("this is the new print outside user fct")
 
         try:
             client_addr = client.client_addr

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -38,10 +38,12 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         log_file = app_dir + '/logs/executor_' + str(partition_id) + '_' + str(task_attempt) + '.log'
         reporter = Reporter(log_file, partition_id, task_attempt)
 
+        original_print = __builtin__.print
+
         def test_print(*args, **kwargs):
             """Maggy custom print() function."""
             reporter.log(*args)
-            __builtin__.print(*args, **kwargs)
+            original_print(*args, **kwargs)
 
         __builtin__.print = test_print
 

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -37,10 +37,11 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         client = rpc.Client(server_addr, partition_id,
                             task_attempt, hb_interval, secret)
         log_file = app_dir + '/logs/executor_' + str(partition_id) + '_' + str(task_attempt) + '.log'
-        reporter = Reporter(log_file, partition_id, task_attempt)
 
         # save the builtin print
         original_print = __builtin__.print
+
+        reporter = Reporter(log_file, partition_id, task_attempt, original_print)
 
         def maggy_print(*args, **kwargs):
             """Maggy custom print() function."""

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -1,3 +1,10 @@
+from __future__ import print_function
+try:
+   import __builtin__
+except ImportError:
+   # Python 3
+   import builtins as __builtin__
+
 import socket
 import time
 from maggy import util, tensorboard, constants
@@ -35,6 +42,13 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                             task_attempt, hb_interval, secret)
         log_file = app_dir + '/logs/executor_' + str(partition_id) + '_' + str(task_attempt) + '.log'
         reporter = Reporter(log_file, partition_id, task_attempt)
+
+        def print(*args, **kwargs):
+            """Maggy custom print() function."""
+            reporter.log(*args)
+            return __builtin__.print(*args, **kwargs)
+
+        print("this is the new print outside user fct")
 
         try:
             client_addr = client.client_addr
@@ -104,3 +118,20 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
             client.close()
 
     return _wrapper_fun
+
+
+from __future__ import print_function
+try:
+   import __builtin__
+except ImportError:
+   # Python 3
+   import builtins as __builtin__
+
+
+def print(*args, **kwargs):
+   """Maggy custom print() function."""
+   reporter.log(*args)
+   # hdfs.log(*args)
+   return __builtin__.print(*args, **kwargs)
+
+print("hello")

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -2,6 +2,7 @@ import builtins as __builtin__
 
 import socket
 import time
+import inspect
 from maggy import util, tensorboard, constants
 from maggy.core import rpc, exceptions, config
 from maggy.core.reporter import Reporter
@@ -82,7 +83,12 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                 try:
                     reporter.log("Starting Trial: {}".format(trial_id), False)
                     reporter.log("Parameter Combination: {}".format(parameters), False)
-                    retval = map_fun(**parameters)
+
+                    sig = inspect.signature(map_fun)
+                    if sig.parameters.get('reporter', None):
+                        retval = map_fun(**parameters, reporter=reporter)
+                    else:
+                        retval = map_fun(**parameters)
 
                     # Make sure user function returns a numeric value
                     if retval is None:

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -113,20 +113,3 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
             client.close()
 
     return _wrapper_fun
-
-
-from __future__ import print_function
-try:
-   import __builtin__
-except ImportError:
-   # Python 3
-   import builtins as __builtin__
-
-
-def print(*args, **kwargs):
-   """Maggy custom print() function."""
-   reporter.log(*args)
-   # hdfs.log(*args)
-   return __builtin__.print(*args, **kwargs)
-
-print("hello")

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -40,7 +40,6 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
 
         def print(*args, **kwargs):
             """Maggy custom print() function."""
-             __builtin__.print('My overridden print() function!')
             reporter.log(*args)
             return __builtin__.print(*args, **kwargs)
 

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -38,12 +38,12 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         log_file = app_dir + '/logs/executor_' + str(partition_id) + '_' + str(task_attempt) + '.log'
         reporter = Reporter(log_file, partition_id, task_attempt)
 
-        def print(*args, **kwargs):
+        def test_print(*args, **kwargs):
             """Maggy custom print() function."""
             reporter.log(*args)
             __builtin__.print(*args, **kwargs)
 
-        __builtin__.print = print
+        __builtin__.print = test_print
 
         print("this is the new print outside user fct")
 

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -41,7 +41,9 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         def print(*args, **kwargs):
             """Maggy custom print() function."""
             reporter.log(*args)
-            return __builtin__.print(*args, **kwargs)
+            __builtin__.print(*args, **kwargs)
+
+        __builtin__.print = print
 
         print("this is the new print outside user fct")
 

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -1,9 +1,4 @@
-from __future__ import print_function
-try:
-   import __builtin__
-except ImportError:
-   # Python 3
-   import builtins as __builtin__
+import builtins as __builtin__
 
 import socket
 import time
@@ -45,6 +40,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
 
         def print(*args, **kwargs):
             """Maggy custom print() function."""
+             __builtin__.print('My overridden print() function!')
             reporter.log(*args)
             return __builtin__.print(*args, **kwargs)
 

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -41,9 +41,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
         def print(*args, **kwargs):
             """Maggy custom print() function."""
             reporter.log(*args)
-            __builtin__.print(*args, **kwargs)
-
-        __builtin__.print = print
+            return __builtin__.print(*args, **kwargs)
 
         print("this is the new print outside user fct")
 

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -42,7 +42,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
 
         def test_print(*args, **kwargs):
             """Maggy custom print() function."""
-            reporter.log(*args)
+            reporter.log(''.join(str(x) for x in args))
             original_print(*args, **kwargs)
 
         __builtin__.print = test_print

--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -82,7 +82,7 @@ def _prepare_func(app_id, run_id, map_fun, server_addr, hb_interval, secret, app
                 try:
                     reporter.log("Starting Trial: {}".format(trial_id), False)
                     reporter.log("Parameter Combination: {}".format(parameters), False)
-                    retval = map_fun(**parameters, reporter=reporter)
+                    retval = map_fun(**parameters)
 
                     # Make sure user function returns a numeric value
                     if retval is None:

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -29,7 +29,7 @@ elastic_id = 1
 experiment_json = None
 
 
-def lagom(map_fun, searchspace, optimizer, direction, num_trials, name, hb_interval=1, es_policy='median', es_interval=300, es_min=10, description=''):
+def lagom(map_fun, searchspace=None, optimizer=None, direction='max', num_trials=1, name='no-name', hb_interval=1, es_policy='median', es_interval=300, es_min=10, description=''):
     """Launches a maggy experiment for hyperparameter optimization.
 
     Given a search space, objective and a model training procedure `map_fun`

--- a/maggy/optimizer/__init__.py
+++ b/maggy/optimizer/__init__.py
@@ -1,3 +1,4 @@
 from maggy.optimizer.abstractoptimizer import AbstractOptimizer
 from maggy.optimizer.randomsearch import RandomSearch
 from maggy.optimizer.asha import Asha
+from maggy.optimizer.singlerun import SingleRun

--- a/maggy/optimizer/singlerun.py
+++ b/maggy/optimizer/singlerun.py
@@ -9,7 +9,8 @@ class SingleRun(AbstractOptimizer):
         self.trial_buffer = []
 
     def initialize(self):
-        self.trial_buffer.append(Trial({}))
+        for _ in range(self.num_trials):
+            self.trial_buffer.append(Trial({}))
 
     def get_suggestion(self, trial=None):
         if self.trial_buffer:

--- a/maggy/optimizer/singlerun.py
+++ b/maggy/optimizer/singlerun.py
@@ -1,0 +1,21 @@
+from maggy.optimizer import AbstractOptimizer
+from maggy.trial import Trial
+
+
+class SingleRun(AbstractOptimizer):
+
+    def __init__(self):
+        super().__init__()
+        self.trial_buffer = []
+
+    def initialize(self):
+        self.trial_buffer.append(Trial({}))
+
+    def get_suggestion(self, trial=None):
+        if self.trial_buffer:
+            return self.trial_buffer.pop()
+        else:
+            return None
+
+    def finalize_experiment(self, trials):
+        return

--- a/maggy/trial.py
+++ b/maggy/trial.py
@@ -2,6 +2,8 @@ import json
 import threading
 import hashlib
 
+from maggy import util
+
 
 class Trial(object):
     """A Trial object contains all relevant information about the evaluation
@@ -80,7 +82,7 @@ class Trial(object):
         raise ValueError("Hyperparameters need to be a dictionary.")
 
     def to_json(self):
-        return json.dumps(self.to_dict())
+        return json.dumps(self.to_dict(), default=util.json_default_numpy)
 
     def to_dict(self):
         obj_dict = {

--- a/maggy/util.py
+++ b/maggy/util.py
@@ -1,5 +1,6 @@
 import socket
 import math
+import numpy as np
 from pyspark.sql import SparkSession
 from pyspark import TaskContext
 
@@ -100,3 +101,14 @@ def _progress_bar(done, total):
 
             bar += ']'
             return bar
+
+def json_default_numpy(obj):
+    if isinstance(obj, np.integer):
+        return int(obj)
+    elif isinstance(obj, np.floating):
+        return float(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
+    else:
+        raise TypeError("Object of type {0}: {1} is not JSON serializable"
+            .format(type(obj), obj))


### PR DESCRIPTION
- Overwrites the print function in the spark executors so users can simply call `print` to log underneath Jupyter cell.
- Adds a single run optimizer, that allows to just run the same model multiple times.
- Until now only one maggy experiment per yarn app id could be run with the progress bar and logging in Jupyter working. Maggy will now reuse the same port, so that sparkmagic can connect multiple times without having to change the REST API in Hopsworks.
- Adds a serializer for numpy datatypes