### PR TITLE
Allow access to optimization direction in optimizer

### DIFF
--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -116,10 +116,6 @@ class ExperimentDriver(object):
                         str(optimizer), type(optimizer).__name__
                     )
                 )
-            # Set references to data in optimizer
-            self.optimizer.num_trials = self.num_trials
-            self.optimizer.searchspace = self.searchspace
-            self.optimizer.final_store = self._final_store
 
             direction = kwargs.get("direction", "max")
             if isinstance(direction, str) and direction.lower() in ["min", "max"]:
@@ -243,6 +239,11 @@ class ExperimentDriver(object):
         self.fd = hopshdfs.open_file(self.log_file, flags="w")
 
     def init(self, job_start):
+        # Set references to data in optimizer
+        self.optimizer.num_trials = self.num_trials
+        self.optimizer.searchspace = self.searchspace
+        self.optimizer.final_store = self._final_store
+        self.optimizer.direction = self.direction
 
         self.server_addr = self.server.start(self)
 

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -239,17 +239,18 @@ class ExperimentDriver(object):
         self.fd = hopshdfs.open_file(self.log_file, flags="w")
 
     def init(self, job_start):
-        # Set references to data in optimizer
-        self.optimizer.num_trials = self.num_trials
-        self.optimizer.searchspace = self.searchspace
-        self.optimizer.final_store = self._final_store
-        self.optimizer.direction = self.direction
 
         self.server_addr = self.server.start(self)
 
         self.job_start = job_start
 
         if self.experiment_type == "optimization":
+            # Set references to data in optimizer
+            self.optimizer.num_trials = self.num_trials
+            self.optimizer.searchspace = self.searchspace
+            self.optimizer.trial_store = self._trial_store
+            self.optimizer.final_store = self._final_store
+            self.optimizer.direction = self.direction
             self.optimizer.initialize()
         elif self.experiment_type == "ablation":
             self.ablator.initialize()

--- a/maggy/optimizer/abstractoptimizer.py
+++ b/maggy/optimizer/abstractoptimizer.py
@@ -6,6 +6,7 @@ class AbstractOptimizer(ABC):
         self.searchspace = None
         self.num_trials = None
         self.final_store = None
+        self.direction = None
 
     @abstractmethod
     def initialize(self):

--- a/maggy/optimizer/abstractoptimizer.py
+++ b/maggy/optimizer/abstractoptimizer.py
@@ -5,6 +5,7 @@ class AbstractOptimizer(ABC):
     def __init__(self):
         self.searchspace = None
         self.num_trials = None
+        self.trial_store = None
         self.final_store = None
         self.direction = None
 


### PR DESCRIPTION
Add reference in optimizer to the optimization direction. This is required for more advaned optimizers.

Also I am moving the setting of the references out of the init of the experimentdriver. To group things a bit more logically.

@ssheikholeslami can you double check, I am not breaking any ablation functionality. We should unify this across optimization and ablation, as we are passing these as arguments when instantiating the Ablator, whereas in optimization we set them separately.