### PR TITLE
Adapt to tensorboard 1.15

### DIFF
--- a/maggy/core/trialexecutor.py
+++ b/maggy/core/trialexecutor.py
@@ -124,7 +124,7 @@ def _prepare_func(
                     reporter.log("Trial Configuration: {}".format(parameters), False)
 
                     if experiment_type == "optimization":
-                        tensorboard._write_hparams(parameters)
+                        tensorboard._write_hparams(parameters, trial_id)
 
                     sig = inspect.signature(map_fun)
                     if sig.parameters.get("reporter", None):

--- a/maggy/tensorboard.py
+++ b/maggy/tensorboard.py
@@ -8,13 +8,7 @@ from tensorboard.plugins.hparams import summary_v2 as hp
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import summary
 
-# from maggy import trial
-
 __import__("tensorflow").compat.v1.enable_eager_execution()
-
-# override HParams id with our trial id
-# 1.15.0 will have functionality to pass custom id
-# hp._derive_session_group_name = trial.Trial._generate_id
 
 _tensorboard_dir = None
 _writer = None

--- a/maggy/tensorboard.py
+++ b/maggy/tensorboard.py
@@ -8,13 +8,13 @@ from tensorboard.plugins.hparams import summary_v2 as hp
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import summary
 
-from maggy import trial
+# from maggy import trial
 
 __import__("tensorflow").compat.v1.enable_eager_execution()
 
 # override HParams id with our trial id
 # 1.15.0 will have functionality to pass custom id
-hp._derive_session_group_name = trial.Trial._generate_id
+# hp._derive_session_group_name = trial.Trial._generate_id
 
 _tensorboard_dir = None
 _writer = None
@@ -82,10 +82,10 @@ def _write_hparams_config(log_dir, searchspace):
         hp.hparams_config(hparams=HPARAMS, metrics=METRICS)
 
 
-def _write_hparams(hparams):
+def _write_hparams(hparams, trial_id):
     global _writer
     with _writer.as_default():
-        hp.hparams(hparams)
+        hp.hparams(hparams, trial_id)
 
 
 def _write_session_end():


### PR DESCRIPTION
With Hopsworks 1.3, we are upgrading to Tensorflow/Tensorboard 1.15.0 which introduced changes in the HParams plugin. This adapts maggy to those changes. One can now directly set a custom trial id for the hparams combinations, we want to use the same id as the internal maggy trial id.