### PR TITLE
[ablation] Fixes TF pickling issue

### DIFF
--- a/examples/maggy-ablation-titanic-example.ipynb
+++ b/examples/maggy-ablation-titanic-example.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*Last Updated: 2020/04/06* </br>\n",
+    "*Last Updated: 2020/04/06*\n",
     "*Created: 2019/10/14*\n",
     "\n",
     "In this notebook, we demonstrate Maggy's Ablation API, while using a TensorFlow Keras Sequential model trained on the [Titanic Dataset](https://www.kaggle.com/c/titanic/data). To be able to follow along, make sure you have the Titanic training dataset registered on your Project's Feature Store, as explained [in this example notebook](https://github.com/logicalclocks/hops-examples/blob/master/notebooks/featurestore/datasets/TitanicTrainingDatasetPython.ipynb).\n",

--- a/examples/maggy-ablation-titanic-example.ipynb
+++ b/examples/maggy-ablation-titanic-example.ipynb
@@ -97,7 +97,6 @@
     }
    ],
    "source": [
-    "import tensorflow as tf\n",
     "from hops import hdfs\n",
     "from hops import featurestore\n",
     "import maggy"
@@ -221,6 +220,7 @@
     "# define the base model generator function\n",
     "\n",
     "def base_model_generator():\n",
+    "    import tensorflow as tf\n",
     "    model = tf.keras.Sequential()\n",
     "    model.add(tf.keras.layers.Dense(64, activation='relu'))\n",
     "    model.add(tf.keras.layers.Dense(64, name='my_dense_two', activation='relu'))\n",

--- a/maggy/ablation/ablationstudy.py
+++ b/maggy/ablation/ablationstudy.py
@@ -48,6 +48,7 @@ class AblationStudy(object):
 
     >>> # you only need to add the `name` parameter to layer initializers
     >>> def base_model_generator():
+    >>>     import tensorflow as tf
     >>>     model = tf.keras.Sequential()
     >>>     model.add(tf.keras.layers.Dense(64, activation='relu'))
     >>>     model.add(tf.keras.layers.Dense(..., name='my_dense_two', ...)

--- a/maggy/ablation/ablator/loco.py
+++ b/maggy/ablation/ablator/loco.py
@@ -37,6 +37,7 @@ class LOCO(AbstractAblator):
 
                 def create_tf_dataset(num_epochs, batch_size):
                     import tensorflow as tf
+
                     dataset_dir = featurestore.get_training_dataset_path(
                         training_dataset_name, training_dataset_version
                     )
@@ -114,6 +115,7 @@ class LOCO(AbstractAblator):
 
         def model_generator():
             import tensorflow as tf
+
             base_model = base_model_generator()
 
             list_of_layers = [

--- a/maggy/ablation/ablator/loco.py
+++ b/maggy/ablation/ablator/loco.py
@@ -2,7 +2,6 @@ from maggy.ablation.ablator import AbstractAblator
 from maggy.core.exceptions import NotSupportedError
 from maggy.core.exceptions import BadArgumentsError
 from hops import featurestore
-import tensorflow as tf
 from maggy.trial import Trial
 import json
 
@@ -37,6 +36,7 @@ class LOCO(AbstractAblator):
             if dataset_type == "tfrecord":
 
                 def create_tf_dataset(num_epochs, batch_size):
+                    import tensorflow as tf
                     dataset_dir = featurestore.get_training_dataset_path(
                         training_dataset_name, training_dataset_version
                     )
@@ -113,6 +113,7 @@ class LOCO(AbstractAblator):
             return base_model_generator
 
         def model_generator():
+            import tensorflow as tf
             base_model = base_model_generator()
 
             list_of_layers = [


### PR DESCRIPTION
With this PR, the `tensorflow` imports in the `ablation` module are moved to the wrapped functions, so `tensorflow` won't be sent to the executors. This avoids the pickling error caused by newer TF versions (see https://github.com/tensorflow/tensorflow/issues/32159 and https://github.com/ray-project/ray/issues/5614#issuecomment-527292289 for more information).

The ablation example notebook is also updated accordingly.