### PR TITLE
Refactor Trial history with iteration steps

### DIFF
--- a/maggy/callbacks.py
+++ b/maggy/callbacks.py
@@ -54,9 +54,10 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
         self.metric.append(logs.get(self.metric_name, 0))
         if self.loss:
             # loss is on per-batch basis and has to be averaged
-            self.reporter.broadcast(sum(self.metric) / float(len(self.metric)), batch)
+            # step attribute is not set to batch since batch gets reset after epoch
+            self.reporter.broadcast(sum(self.metric) / float(len(self.metric)))
         else:
-            self.reporter.broadcast(logs.get(self.metric_name, 0), batch)
+            self.reporter.broadcast(logs.get(self.metric_name, 0))
 
     def on_epoch_end(self, epoch, logs={}):
         self.metric = []

--- a/maggy/callbacks.py
+++ b/maggy/callbacks.py
@@ -38,6 +38,9 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
         self.metric_name = metric
         self.reporter = reporter
         self.metric = []
+        self.loss = False
+        if "loss" == metric:
+            self.loss = True
 
     def on_train_begin(self, logs=None):
         if self.metric_name not in self.model.metrics_names:
@@ -49,7 +52,11 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
 
     def on_batch_end(self, batch, logs={}):
         self.metric.append(logs.get(self.metric_name, 0))
-        self.reporter.broadcast(sum(self.metric) / float(len(self.metric)))
+        if self.loss:
+            # loss is on per-batch basis and has to be averaged
+            self.reporter.broadcast(sum(self.metric) / float(len(self.metric)), batch)
+        else:
+            self.reporter.broadcast(logs.get(self.metric_name, 0), batch)
 
     def on_epoch_end(self, epoch, logs={}):
         self.metric = []
@@ -84,4 +91,4 @@ class KerasEpochEnd(tf.keras.callbacks.Callback):
             )
 
     def on_epoch_end(self, epoch, logs={}):
-        self.reporter.broadcast(logs.get(self.metric_name, 0))
+        self.reporter.broadcast(logs.get(self.metric_name, 0), epoch)

--- a/maggy/core/exceptions.py
+++ b/maggy/core/exceptions.py
@@ -66,6 +66,48 @@ class MetricTypeError(TypeError):
         super().__init__(self.message)
 
 
+class BroadcastMetricTypeError(TypeError):
+    """User defined training function broadcasts metric of wrong type."""
+
+    def __init__(self, return_type):
+        self.message = (
+            "The optimization metric broadcast by the training function with "
+            "the reporter is of type: {}. The optimization metric can only "
+            "be numeric".format(type(return_type).__name__)
+        )
+        super().__init__(self.message)
+
+
+class BroadcastStepTypeError(TypeError):
+    """User defined training function broadcasts metric with a non-numeric step
+    type.
+    """
+
+    def __init__(self, value, step):
+        self.message = (
+            "The optimization metric `{}` was broadcast by the training "
+            " function in step {}, which is of type {}. The step value can "
+            "only be numeric.".format(value, step, type(value).__name__)
+        )
+        super().__init__(self.message)
+
+
+class BroadcastStepValueError(ValueError):
+    """User defined training function broadcasts metric with a
+    non-monotonically increasing step attribute.
+    """
+
+    def __init__(self, value, step, prev_step):
+        self.message = (
+            "The optimization metric `{}` was broadcast by the training "
+            " function in step {}, while the previous step was {}. The steps "
+            "should be a monotonically increasing attribute.".format(
+                value, step, prev_step
+            )
+        )
+        super().__init__(self.message)
+
+
 class BadArgumentsError(Exception):
     """Raised when a function or method has been called with incompatible arguments.
     This can be used by developers to prevent bad usage of their functions

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -586,7 +586,7 @@ class Client(MessageSocket):
         # make sure heartbeat thread can't send between sending final metric
         # and resetting the reporter
         with reporter.lock:
-            _, logs = reporter.get_data()
+            _, _, logs = reporter.get_data()
             resp = self._request(
                 self.sock, "FINAL", metric, reporter.get_trial_id(), logs
             )

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -525,10 +525,11 @@ class Client(MessageSocket):
 
             while not self.done:
 
-                metric, logs = report.get_data()
+                metric, step, logs = report.get_data()
+                data = {"value": metric, "step": step}
 
                 resp = self._request(
-                    self.hb_sock, "METRIC", metric, report.get_trial_id(), logs
+                    self.hb_sock, "METRIC", data, report.get_trial_id(), logs
                 )
                 _ = self._handle_message(resp, report)
 

--- a/maggy/trial.py
+++ b/maggy/trial.py
@@ -63,6 +63,8 @@ class Trial(object):
         self.early_stop = False
         self.final_metric = None
         self.metric_history = []
+        self.step_history = []
+        self.metric_dict = {}
         self.start = None
         self.duration = None
         self.lock = threading.RLock()
@@ -77,10 +79,15 @@ class Trial(object):
         with self.lock:
             self.early_stop = True
 
-    def append_metric(self, metric):
+    def append_metric(self, metric_data):
         """Append a metric from the heartbeats to the history."""
         with self.lock:
-            self.metric_history.append(metric)
+            # from python 3.7 dicts are insertion ordered,
+            # so two of these data structures can be removed
+            if metric_data["step"] not in self.metric_dict:
+                self.metric_dict[metric_data["step"]] = metric_data["value"]
+                self.metric_history.append(metric_data["value"])
+                self.step_history.append(metric_data["step"])
 
     @classmethod
     def _generate_id(cls, params):

--- a/maggy/trial.py
+++ b/maggy/trial.py
@@ -84,7 +84,10 @@ class Trial(object):
         with self.lock:
             # from python 3.7 dicts are insertion ordered,
             # so two of these data structures can be removed
-            if metric_data["step"] not in self.metric_dict:
+            if (
+                metric_data["step"] not in self.metric_dict
+                and metric_data["value"] is not None
+            ):
                 self.metric_dict[metric_data["step"]] = metric_data["value"]
                 self.metric_history.append(metric_data["value"])
                 self.step_history.append(metric_data["step"])


### PR DESCRIPTION
Changes the reporter API, to include a step argument, to indicate the iteration step.
This is necessary to deduplicate the heartbeats on the Maggy ExperimentDriver side.

Updates the Keras callbacks accordingly.