### PR TITLE
Reduce server timeout to shutdown faster

### DIFF
--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -388,7 +388,7 @@ class Server(MessageSocket):
             CONNECTIONS.append(sock)
 
             while not self.done:
-                read_socks, _, _ = select.select(CONNECTIONS, [], [], 60)
+                read_socks, _, _ = select.select(CONNECTIONS, [], [], 5)
                 for sock in read_socks:
                     if sock == server_sock:
                         client_sock, client_addr = sock.accept()

--- a/maggy/core/rpc.py
+++ b/maggy/core/rpc.py
@@ -388,7 +388,7 @@ class Server(MessageSocket):
             CONNECTIONS.append(sock)
 
             while not self.done:
-                read_socks, _, _ = select.select(CONNECTIONS, [], [], 5)
+                read_socks, _, _ = select.select(CONNECTIONS, [], [], 1)
                 for sock in read_socks:
                     if sock == server_sock:
                         client_sock, client_addr = sock.accept()


### PR DESCRIPTION
When running many experiments after another in a loop, the server is not shutting down fast enough
and therefore the port is still in use.

This can be changed if the Hopsworks endpoint is changed to allow for different ports per app.