### PR TITLE
Iteration step based early stop checks instead of time interval based

### DIFF
--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -401,21 +401,24 @@ class ExperimentDriver(object):
                         # i.e. step nr is added to the queue as message which will
                         # then later be checked for early stopping, just to not
                         # block for too long for other messages
-                        if len(self._final_store) > self.es_min:
-                            if step is not None and step != 0:
-                                if step % self.es_interval == 0:
-                                    try:
-                                        to_stop = self.earlystop_check(
-                                            self.get_trial(msg["trial_id"]),
-                                            self._final_store,
-                                            self.direction,
-                                        )
-                                    except Exception as e:
-                                        self._log(e)
-                                        to_stop = None
-                                    if to_stop is not None:
-                                        self._log("Trials to stop: {}".format(to_stop))
-                                        self.get_trial(to_stop).set_early_stop()
+                        if self.earlystop_check != NoStoppingRule.earlystop_check:
+                            if len(self._final_store) > self.es_min:
+                                if step is not None and step != 0:
+                                    if step % self.es_interval == 0:
+                                        try:
+                                            to_stop = self.earlystop_check(
+                                                self.get_trial(msg["trial_id"]),
+                                                self._final_store,
+                                                self.direction,
+                                            )
+                                        except Exception as e:
+                                            self._log(e)
+                                            to_stop = None
+                                        if to_stop is not None:
+                                            self._log(
+                                                "Trials to stop: {}".format(to_stop)
+                                            )
+                                            self.get_trial(to_stop).set_early_stop()
 
                         # 2. BLACKLIST the trial
                     elif msg["type"] == "BLACK":

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -426,15 +426,9 @@ class ExperimentDriver(object):
                         # i.e. step nr is added to the queue as message which will
                         # then later be checked for early stopping, just to not
                         # block for too long for other messages
-                        if step is not None and step != 0:
-                            if len(self._final_store) > self.es_min:
-                                # this can later be parametrized to check only every N steps
-                                if step % 1 == 0:
-                                    self._log(
-                                        "Check for early stopping. Trial {}, step {}".format(
-                                            msg["trial_id"], step
-                                        )
-                                    )
+                        if len(self._final_store) > self.es_min:
+                            if step is not None and step != 0:
+                                if step % self.es_interval == 0:
                                     try:
                                         to_stop = self.earlystop_check(
                                             self.get_trial(msg["trial_id"]),

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -373,10 +373,6 @@ class ExperimentDriver(object):
         def _target_function(self):
 
             try:
-                # time_earlystop_check = (
-                #     time.time()
-                # )  # only used by earlystop-supporting experiments
-
                 while not self.worker_done:
                     trial = None
                     # get a message
@@ -384,27 +380,6 @@ class ExperimentDriver(object):
                         msg = self._message_q.get_nowait()
                     except queue.Empty:
                         msg = {"type": None}
-
-                    # if self.earlystop_check != NoStoppingRule.earlystop_check:
-                    #     if (time.time() - time_earlystop_check) >= self.es_interval:
-                    #         time_earlystop_check = time.time()
-
-                    #         # pass currently running trials to early stop component
-                    #         if len(self._final_store) > self.es_min:
-                    #             self._log("Check for early stopping.")
-                    #             try:
-                    #                 to_stop = self.earlystop_check(
-                    #                     self._trial_store,
-                    #                     self._final_store,
-                    #                     self.direction,
-                    #                 )
-                    #             except Exception as e:
-                    #                 self._log(e)
-                    #                 to_stop = []
-                    #             if len(to_stop) > 0:
-                    #                 self._log("Trials to stop: {}".format(to_stop))
-                    #             for trial_id in to_stop:
-                    #                 self.get_trial(trial_id).set_early_stop()
 
                     # depending on message do the work
                     # 1. METRIC

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -441,9 +441,7 @@ class ExperimentDriver(object):
                                         to_stop = None
                                     if to_stop is not None:
                                         self._log("Trials to stop: {}".format(to_stop))
-                                        self.get_trial(
-                                            to_stop.trial_id
-                                        ).set_early_stop()
+                                        self.get_trial(to_stop).set_early_stop()
 
                         # 2. BLACKLIST the trial
                     elif msg["type"] == "BLACK":

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -415,6 +415,7 @@ class ExperimentDriver(object):
                             with self.log_lock:
                                 self.executor_logs = self.executor_logs + logs
 
+                        step = None
                         if msg["trial_id"] is not None and msg["data"] is not None:
                             step = self.get_trial(msg["trial_id"]).append_metric(
                                 msg["data"]

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -430,6 +430,11 @@ class ExperimentDriver(object):
                             if len(self._final_store) > self.es_min:
                                 # this can later be parametrized to check only every N steps
                                 if step % 1 == 0:
+                                    self._log(
+                                        "Check for early stopping. Trial {}, step {}".format(
+                                            msg["trial_id"], step
+                                        )
+                                    )
                                     try:
                                         to_stop = self.earlystop_check(
                                             self.get_trial(msg["trial_id"]),

--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -440,11 +440,7 @@ class ExperimentDriver(object):
                                         self._log(e)
                                         to_stop = None
                                     if to_stop is not None:
-                                        self._log(
-                                            "Trials to stop: {}".format(
-                                                to_stop.trial_id
-                                            )
-                                        )
+                                        self._log("Trials to stop: {}".format(to_stop))
                                         self.get_trial(
                                             to_stop.trial_id
                                         ).set_early_stop()

--- a/maggy/earlystop/nostop.py
+++ b/maggy/earlystop/nostop.py
@@ -23,5 +23,4 @@ class NoStoppingRule(AbstractEarlyStop):
 
     @staticmethod
     def earlystop_check(to_check, finalized_trials, direction):
-        stop = []
-        return stop
+        return None

--- a/maggy/experiment.py
+++ b/maggy/experiment.py
@@ -53,7 +53,7 @@ def lagom(
     optimization_key="metric",
     hb_interval=1,
     es_policy="median",
-    es_interval=300,
+    es_interval=1,
     es_min=10,
     description="",
 ):
@@ -97,8 +97,8 @@ def lagom(
     :type hb_interval: int, optional
     :param es_policy: The earlystopping policy, defaults to 'median'
     :type es_policy: str, optional
-    :param es_interval: Frequency interval in seconds to check currently
-        running trials for early stopping, defaults to 300
+    :param es_interval: Frequency interval in number of steps to check currently
+        running trials for early stopping, defaults to 1.
     :type es_interval: int, optional
     :param es_min: Minimum number of trials finalized before checking for
         early stopping, defaults to 10

--- a/maggy/trial.py
+++ b/maggy/trial.py
@@ -91,6 +91,10 @@ class Trial(object):
                 self.metric_dict[metric_data["step"]] = metric_data["value"]
                 self.metric_history.append(metric_data["value"])
                 self.step_history.append(metric_data["step"])
+                # return step number to indicate that it was a new unique step
+                return metric_data["step"]
+            # return None to indicate that no new step has finished
+            return None
 
     @classmethod
     def _generate_id(cls, params):


### PR DESCRIPTION
Every time a new metric/heartbeat with a new unique step number arrives, a early stop check is performed for this trial.

`es_interval` argument in `lagom` changes from time in seconds to be number of steps, in order to change how often a trial is checked for early stopping. Default is 1.