### PR TITLE
Add possibility to return IDLE after REG message

### DIFF
--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -526,7 +526,14 @@ class ExperimentDriver(object):
                         elif self.experiment_type == "ablation":
                             trial = self.ablator.get_trial()
                         if trial is None:
+                            self.server.reservations.assign_trial(
+                                msg["partition_id"], None
+                            )
                             self.experiment_done = True
+                        elif trial == "IDLE":
+                            # reset timeout
+                            msg["idle_start"] = time.time()
+                            self.add_message(msg)
                         else:
                             with trial.lock:
                                 trial.start = time.time()


### PR DESCRIPTION
In some cases, e.g. when running a single SHA bracket in HyperBand and with many executors available it might be necessary to have idle executors right from the start.