### PR TITLE
[core] Initialize custom ablator with final_store of exp_driver

### DIFF
--- a/maggy/core/experimentdriver.py
+++ b/maggy/core/experimentdriver.py
@@ -269,6 +269,9 @@ class ExperimentDriver(object):
             self.optimizer.direction = self.direction
             self.optimizer.initialize()
         elif self.experiment_type == "ablation":
+            # set references to data in ablator
+            self.ablator.ablation_study = self.ablation_study
+            self.ablator.final_store = self._final_store
             self.ablator.initialize()
 
         self._start_worker()


### PR DESCRIPTION
If a user implements a custom ablator, the `final_store` attribute of the custom ablator will now refer to the `final_store` of the `ExperimentDriver` instance.