### PR TITLE
Upgrade Callbacks to TF2.2

### DIFF
--- a/maggy/callbacks.py
+++ b/maggy/callbacks.py
@@ -37,10 +37,6 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
         super().__init__()
         self.metric_name = metric
         self.reporter = reporter
-        self.metric = []
-        self.loss = False
-        if "loss" == metric:
-            self.loss = True
 
     def on_train_begin(self, logs=None):
         # if self.metric_name not in self.model.metrics_names:
@@ -52,16 +48,7 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
         pass
 
     def on_batch_end(self, batch, logs={}):
-        self.metric.append(logs.get(self.metric_name, 0))
-        if self.loss:
-            # loss is on per-batch basis and has to be averaged
-            # step attribute is not set to batch since batch gets reset after epoch
-            self.reporter.broadcast(sum(self.metric) / float(len(self.metric)))
-        else:
-            self.reporter.broadcast(logs.get(self.metric_name, 0))
-
-    def on_epoch_end(self, epoch, logs={}):
-        self.metric = []
+        self.reporter.broadcast(logs.get(self.metric_name, 0))
 
 
 class KerasEpochEnd(tf.keras.callbacks.Callback):

--- a/maggy/callbacks.py
+++ b/maggy/callbacks.py
@@ -43,12 +43,13 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
             self.loss = True
 
     def on_train_begin(self, logs=None):
-        if self.metric_name not in self.model.metrics_names:
-            raise ValueError(
-                "The choosen metric {0} is not monitored: {1}".format(
-                    self.metric_name, self.model.metrics_names
-                )
-            )
+        # if self.metric_name not in self.model.metrics_names:
+        #     raise ValueError(
+        #         "The choosen metric {0} is not monitored: {1}".format(
+        #             self.metric_name, self.model.metrics_names
+        #         )
+        #     )
+        pass
 
     def on_batch_end(self, batch, logs={}):
         self.metric.append(logs.get(self.metric_name, 0))
@@ -84,12 +85,13 @@ class KerasEpochEnd(tf.keras.callbacks.Callback):
         self.reporter = reporter
 
     def on_train_begin(self, logs=None):
-        if self.metric_name not in self.model.metrics_names:
-            raise ValueError(
-                "The choosen metric {0} is not monitored: {1}".format(
-                    self.metric_name, self.model.metrics_names
-                )
-            )
+        # if self.metric_name not in self.model.metrics_names:
+        #     raise ValueError(
+        #         "The choosen metric {0} is not monitored: {1}".format(
+        #             self.metric_name, self.model.metrics_names
+        #         )
+        #     )
+        pass
 
     def on_epoch_end(self, epoch, logs={}):
         self.reporter.broadcast(logs.get(self.metric_name, 0), epoch)

--- a/maggy/callbacks.py
+++ b/maggy/callbacks.py
@@ -38,15 +38,6 @@ class KerasBatchEnd(tf.keras.callbacks.Callback):
         self.metric_name = metric
         self.reporter = reporter
 
-    def on_train_begin(self, logs=None):
-        # if self.metric_name not in self.model.metrics_names:
-        #     raise ValueError(
-        #         "The choosen metric {0} is not monitored: {1}".format(
-        #             self.metric_name, self.model.metrics_names
-        #         )
-        #     )
-        pass
-
     def on_batch_end(self, batch, logs={}):
         self.reporter.broadcast(logs.get(self.metric_name, 0))
 
@@ -70,15 +61,6 @@ class KerasEpochEnd(tf.keras.callbacks.Callback):
         super().__init__()
         self.metric_name = metric
         self.reporter = reporter
-
-    def on_train_begin(self, logs=None):
-        # if self.metric_name not in self.model.metrics_names:
-        #     raise ValueError(
-        #         "The choosen metric {0} is not monitored: {1}".format(
-        #             self.metric_name, self.model.metrics_names
-        #         )
-        #     )
-        pass
 
     def on_epoch_end(self, epoch, logs={}):
         self.reporter.broadcast(logs.get(self.metric_name, 0), epoch)

--- a/maggy/tensorboard.py
+++ b/maggy/tensorboard.py
@@ -24,7 +24,7 @@ from tensorboard.plugins.hparams import summary_v2 as hp
 from tensorboard.plugins.hparams import api_pb2
 from tensorboard.plugins.hparams import summary
 
-__import__("tensorflow").compat.v1.enable_eager_execution()
+# __import__("tensorflow").compat.v1.enable_eager_execution()
 
 _tensorboard_dir = None
 _writer = None
@@ -82,9 +82,11 @@ def _create_hparams_config(searchspace):
 def _write_hparams_config(log_dir, searchspace):
     HPARAMS = _create_hparams_config(searchspace)
     METRICS = [
-        hp.Metric("epoch_acc", group="validation", display_name="accuracy (val.)",),
+        hp.Metric(
+            "epoch_accuracy", group="validation", display_name="accuracy (val.)",
+        ),
         hp.Metric("epoch_loss", group="validation", display_name="loss (val.)",),
-        hp.Metric("epoch_acc", group="train", display_name="accuracy (train)",),
+        hp.Metric("epoch_accuracy", group="train", display_name="accuracy (train)",),
         hp.Metric("epoch_loss", group="train", display_name="loss (train)",),
     ]
 


### PR DESCRIPTION
callbacks were changed in TF2:
- you cannot check for the available metrics anymore before there wasn't an actual validation step run
- in tf 1.15 loss was on per-batch basis and had to be averaged over batches manually. now accuracy and loss behave the same and are running averages over batches.