### PR TITLE
update install requirements versions, fix Bayesian Hyperparameter Optimizer bug

### DIFF
--- a/maggy/core/experiment_driver/optimization_driver.py
+++ b/maggy/core/experiment_driver/optimization_driver.py
@@ -40,10 +40,11 @@ class OptimizationDriver(Driver):
     optimization.
     """
 
+    # When adding a controller_dict entry, make sure the key is in lower case
     controller_dict = {
         "randomsearch": RandomSearch,
         "asha": Asha,
-        "TPE": bayes.TPE,
+        "tpe": bayes.TPE,
         "gp": bayes.GP,
         "none": SingleRun,
         "faulty_none": None,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     name='maggy',
     version=version,
     install_requires=[
-        'numpy==1.19.2', 'scikit-optimize==0.7.4', 'statsmodels==0.11.0', 'scipy==1.4.1'
+        'numpy==1.19.2', 'scikit-optimize==0.7.4', 'statsmodels==0.12.2', 'scipy==1.6.3'
     ],
     extras_require={
         'pydoop': ['pydoop'],


### PR DESCRIPTION
The dictionary containing the HPO algorithms contained "TPE" while it should be "tpe" as the keys in input are forced to low cases only.